### PR TITLE
fixed dependency on abandoned (renamed) package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=7.2.0",
-        "endroid/qrcode": "~1.1.3"
+        "endroid/qr-code": "~1.1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.2.4"


### PR DESCRIPTION
https://packagist.org/packages/endroid/qrcode is marked as Abandoned (was just renamed to https://packagist.org/packages/endroid/qr-code)